### PR TITLE
SN-2830 Wrong order of assets on new accounts fix

### DIFF
--- a/SoraPassport/Common/AssetProvider/AssetProvider.swift
+++ b/SoraPassport/Common/AssetProvider/AssetProvider.swift
@@ -53,7 +53,14 @@ final class AssetProvider {
 
 extension AssetProvider: AssetProviderProtocol {
     func getBalances(with assetIds: [String]) -> [BalanceData] {
-        return balanceData.filter { assetIds.contains($0.identifier) }
+        var balances: [BalanceData] = []
+        
+        for id in assetIds {
+            guard let assetBalance = balanceData.first(where: { $0.identifier == id }) else { continue }
+            balances.append(assetBalance)
+        }
+
+        return balances
     }
     
     func add(observer: AssetProviderObserverProtocol) {


### PR DESCRIPTION
Method filter returned unexpected order of items what's why I have to reimplement method getBalance